### PR TITLE
[5] feat: validar PRs abiertas antes de crear nueva rama/PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lansisdev/gh-createpr",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lansisdev/gh-createpr",
-      "version": "1.4.6",
+      "version": "1.4.8",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lansisdev/gh-createpr",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "main": "dist/index.js",
   "bin": {
     "gh-createpr": "dist/index.js"

--- a/src/github.ts
+++ b/src/github.ts
@@ -100,6 +100,15 @@ export const fetchOpenIssues = async (): Promise<Array<{number: number, title: s
   return issues;
 };
 
+export const fetchOpenPRs = (): Array<{number: number, title: string, headRefName: string, baseRefName: string}> => {
+  try {
+    const output = execSync('gh pr list --state OPEN --json number,title,headRefName,baseRefName --limit 50', { encoding: 'utf-8' });
+    return JSON.parse(output);
+  } catch {
+    return [];
+  }
+};
+
 export const createPrFromGithubIssue = async (issueArg: string, options?: { isInteractiveCLI?: boolean }) => {
   const issueRegex = /^(?:([a-zA-Z0-9-]+)\/([a-zA-Z0-9._-]+)#(\d+)|#(\d+)|(\d+))$/;
   const match = issueArg.match(issueRegex);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,37 @@ import { Command } from "commander";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { createPrFromJira, fetchOpenJiraTickets, getJiraProjectKey } from "./jira.js";
-import { createPrFromGithubIssue, fetchOpenIssues } from "./github.js";
+import { createPrFromGithubIssue, fetchOpenIssues, fetchOpenPRs } from "./github.js";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
+
+const checkOpenPRsBeforeProceed = async (): Promise<boolean> => {
+  const s = p.spinner();
+  s.start('Checking for open PRs...');
+  const openPRs = fetchOpenPRs();
+  s.stop(openPRs.length > 0 ? `${openPRs.length} open PR(s) found.` : 'No open PRs found. All clear!');
+
+  if (openPRs.length === 0) return true;
+
+  p.note(
+    openPRs.map(pr => `#${pr.number} - ${pr.title} ${pc.gray(`(${pr.headRefName} → ${pr.baseRefName})`)}`).join('\n'),
+    `📋 You have ${openPRs.length} open PR(s)`
+  );
+
+  const shouldContinue = await p.confirm({
+    message: 'Hay PRs abiertas sin mergear. ¿Querés continuar o preferís cancelar para mergearlas primero?',
+    initialValue: false,
+  });
+
+  if (p.isCancel(shouldContinue) || !shouldContinue) {
+    p.cancel('Operación cancelada. Mergeá las PRs abiertas primero y volvé a intentarlo.');
+    return false;
+  }
+
+  return true;
+};
 
 const program = new Command();
 
@@ -24,6 +50,10 @@ program
   .action(async (ticket: string | undefined) => {
     let finalTicket = ticket;
     
+    if (!(await checkOpenPRsBeforeProceed())) {
+      process.exit(0);
+    }
+
     if (!finalTicket) {
       p.intro(pc.bgBlue(pc.white(" gh-createpr: Jira ")));
       const result = await p.text({
@@ -50,6 +80,10 @@ program
   .action(async (issue: string | undefined) => {
     let finalIssue = issue;
     
+    if (!(await checkOpenPRsBeforeProceed())) {
+      process.exit(0);
+    }
+
     if (!finalIssue) {
       p.intro(pc.bgMagenta(pc.white(" gh-createpr: GitHub Issue ")));
       const result = await p.text({
@@ -71,6 +105,11 @@ program
 
 program.action(async () => {
   p.intro(pc.bgCyan(pc.black(" gh-createpr: Interactive CLI ")));
+
+  // Check for open PRs before starting
+  if (!(await checkOpenPRsBeforeProceed())) {
+    process.exit(0);
+  }
 
   let currentState = "SELECT_SOURCE";
   let sourceType = "";


### PR DESCRIPTION
**Resolves #5**

## Cambios

Antes de crear una nueva branch/PR (tanto en modo interactivo como en comandos directos), ahora se valida si hay PRs abiertas sin mergear.

### Nuevas funciones:
- **`fetchOpenPRs()`** en `src/github.ts` — usa `gh pr list --state OPEN` para obtener PRs abiertas
- **`checkOpenPRsBeforeProceed()`** en `src/index.ts` — spinner + prompt que pregunta si continuar o cancelar

### Entry points que checkean:
1. Modo interactivo (`gh-createpr` sin subcomando)
2. Comando `jira` (`gh-createpr jira LAN-3`)
3. Comando `github` (`gh-createpr github #123`)

### Flujo:
```
◆ Checking for open PRs...
  ✓ 2 open PR(s) found.

📋 You have 2 open PR(s)
  #4 - fix: ... (branch → develop)
  #5 - feat: ... (other-branch → develop)

◆ Hay PRs abiertas sin mergear. ¿Querés continuar o preferís cancelar para mergearlas primero?
  ● No / ○ Yes
```

Si no hay PRs abiertas → sigue derecho sin preguntar.